### PR TITLE
Add `ocaml` dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -8,4 +8,5 @@
 
 (package
    (name roman)
-   (synopsis "Manipulate roman numerals (ocaml.org dune/opam tutorial)"))
+   (synopsis "Manipulate roman numerals (ocaml.org dune/opam tutorial)")
+   (depends ocaml))

--- a/roman.opam
+++ b/roman.opam
@@ -8,6 +8,7 @@ homepage: "https://github.com/johnwhitington/roman"
 bug-reports: "https://github.com/johnwhitington/roman/issues"
 depends: [
   "dune" {>= "2.8"}
+  "ocaml"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This way the package can be built with Dune package management (and the code does need some ocaml compiler in either case).